### PR TITLE
Update setup.rb to include new rb-fsevent-0.9.3

### DIFF
--- a/Resources/vendor/bundle/bundler/setup.rb
+++ b/Resources/vendor/bundle/bundler/setup.rb
@@ -2,4 +2,4 @@ path = File.expand_path('..', __FILE__)
 
 $:.unshift File.expand_path("#{path}/../ruby/1.8/gems/json-1.7.5/lib")
 $:.unshift File.expand_path("#{path}/../ruby/1.8/bundler/gems/listen-2f0aa9b283ad/lib")
-$:.unshift File.expand_path("#{path}/../ruby/1.8/gems/rb-fsevent-0.9.1/lib")
+$:.unshift File.expand_path("#{path}/../ruby/1.8/gems/rb-fsevent-0.9.3/lib")


### PR DESCRIPTION
Updated bundler reference to rb-fsevent-0.9.3 to fix issue in OS X Mavericks not detecting/listening correctly to theme folder. 

Fixes my issue @ https://github.com/meeech/Shopify-Theme-Tool/issues/7 which was based on https://github.com/Shopify/theme-sync/issues/10
